### PR TITLE
More refactorings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,11 @@ go:
   - "1.8.x"
   - "1.9.x"
   - "1.10.x"
+
+before_install:
+  - go get -u gopkg.in/alecthomas/gometalinter.v2
+  - gometalinter.v2 --install
+
+script:
+  - gometalinter.v2 --disable=gas --disable=gocyclo ./...
+  - go test -v ./...

--- a/README.md
+++ b/README.md
@@ -68,4 +68,7 @@ tpl.ExecuteTemplate(&sm.Text, "email", &struct{ Name string }{"Dominik"})
 
 ## ToDo
 
-* HTML emails
+- [x] HTML emails
+- [ ] multipart emails (HTML + Text)
+- [ ] attachments
+- [ ] inline attachments

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-Go sendmail [![Build Status](https://travis-ci.org/meehow/sendmail.svg?branch=master)](https://travis-ci.org/meehow/sendmail)
-===========
+# Go sendmail
 
-This package implements classic, well known from PHP, method of sending emails.
-It's stupid simple and it works not only with Sendmail,
-but also with other MTAs, like [Postfix](http://www.postfix.org/sendmail.1.html)
-or [sSMTP](https://wiki.debian.org/sSMTP), which provide compatibility interface.
+[![GoDoc](https://godoc.org/github.com/meehow/sendmail?status.svg)](https://godoc.org/github.com/meehow/sendmail)
+[![Build Status](https://travis-ci.org/meehow/sendmail.svg?branch=master)](https://travis-ci.org/meehow/sendmail)
+
+
+This package implements the classic method of sending emails, well known
+from PHP. It's stupid simple and it works not only with Sendmail, but also
+with other MTAs, like [Postfix][], [sSMTP][], or [mhsendmail][], which
+provide a compatible interface.
+
+[Postfix]:    http://www.postfix.org/sendmail.1.html
+[sSMTP]:      https://wiki.debian.org/sSMTP
+[mhsendmail]: https://github.com/mailhog/mhsendmail
 
 * it separates email headers from email body,
 * encodes UTF-8 headers like `Subject`, `From`, `To`
@@ -13,14 +20,15 @@ or [sSMTP](https://wiki.debian.org/sSMTP), which provide compatibility interface
 * outputs emails to _stdout_ when environment variable `DEBUG` is set.
 * by default, it just uses `/usr/sbin/sendmail` (but can be changed if need be)
 
-Installation
-------------
+
+## Installation
+
 ```
 go get -u github.com/meehow/sendmail
 ```
 
-Usage
------
+## Usage
+
 ```go
 package main
 
@@ -58,7 +66,6 @@ tpl.ExecuteTemplate(&sm.Text, "email", &struct{ Name string }{"Dominik"})
 ```
 
 
-ToDo
-----
+## ToDo
 
 * HTML emails

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ provide a compatible interface.
 * encodes UTF-8 headers like `Subject`, `From`, `To`
 * makes it easy to use [text/template](https://golang.org/pkg/text/template)
 * doesn't require any SMTP configuration,
-* outputs emails to _stdout_ when environment variable `DEBUG` is set.
+* can write email body to a custom `io.Writer` to simplify testing
 * by default, it just uses `/usr/sbin/sendmail` (but can be changed if need be)
 
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ or [sSMTP](https://wiki.debian.org/sSMTP), which provide compatibility interface
 * encodes UTF-8 headers like `Subject`, `From`, `To`
 * makes it easy to use [text/template](https://golang.org/pkg/text/template)
 * doesn't require any SMTP configuration,
-* just uses `/usr/sbin/sendmail` command which is present on most of the systems,
-  * if not, just update `sendmail.Binary`
 * outputs emails to _stdout_ when environment variable `DEBUG` is set.
+* by default, it just uses `/usr/sbin/sendmail` (but can be changed if need be)
 
 Installation
 ------------

--- a/options.go
+++ b/options.go
@@ -33,20 +33,20 @@ func (m *Mail) SetDebugOutput(w io.Writer) *Mail {
 }
 
 // AppendTo adds a recipient to the Mail.
-func (m *Mail) AppendTo(toAddress *mail.Address) *Mail {
-	m.To = append(m.To, toAddress)
+func (m *Mail) AppendTo(toAddress ...*mail.Address) *Mail {
+	m.To = append(m.To, toAddress...)
 	return m
 }
 
 // AppendCC adds a carbon-copy recipient to the Mail.
-func (m *Mail) AppendCC(ccAddress *mail.Address) *Mail {
-	m.CC = append(m.CC, ccAddress)
+func (m *Mail) AppendCC(ccAddress ...*mail.Address) *Mail {
+	m.CC = append(m.CC, ccAddress...)
 	return m
 }
 
 // AppendBCC adds a blind carbon-copy recipient to the Mail.
-func (m *Mail) AppendBCC(bccAddress *mail.Address) *Mail {
-	m.BCC = append(m.BCC, bccAddress)
+func (m *Mail) AppendBCC(bccAddress ...*mail.Address) *Mail {
+	m.BCC = append(m.BCC, bccAddress...)
 	return m
 }
 

--- a/options.go
+++ b/options.go
@@ -2,6 +2,7 @@ package sendmail
 
 import (
 	"io"
+	"net/mail"
 	"os"
 )
 
@@ -26,5 +27,26 @@ func (m *Mail) SetDebug(active bool) *Mail {
 // nil, this is equivalent to SetDebug(false).
 func (m *Mail) SetDebugOutput(w io.Writer) *Mail {
 	m.debugOut = w
+	return m
+}
+
+// AppendTo adds a recipient to the Mail. The name argument is the
+// "proper name" of the recipient and may be empty. The address must be
+// in the form "user@domain".
+func (m *Mail) AppendTo(name, address string) *Mail {
+	m.To = append(m.To, &mail.Address{Name: name, Address: address})
+	return m
+}
+
+// SetFrom updates the sender's address. Like AppendTo(), name may be
+// empty, and address must be in the form "user@domain".
+func (m *Mail) SetFrom(name, address string) *Mail {
+	m.From = &mail.Address{Name: name, Address: address}
+	return m
+}
+
+// SetSubject sets the mail subject.
+func (m *Mail) SetSubject(subject string) *Mail {
+	m.Subject = subject
 	return m
 }

--- a/options.go
+++ b/options.go
@@ -1,7 +1,30 @@
 package sendmail
 
+import (
+	"io"
+	"os"
+)
+
 // SetSendmail modifies the path to the sendmail binary.
 func (m *Mail) SetSendmail(path string) *Mail {
 	m.sendmail = path
+	return m
+}
+
+// SetDebug sets the debug output to stderr if active is true, else it
+// removes the debug output. Use SetDebugOutput to set it to something else.
+func (m *Mail) SetDebug(active bool) *Mail {
+	var out io.Writer
+	if active {
+		out = os.Stderr
+	}
+	m.debugOut = out
+	return m
+}
+
+// SetDebugOutput sets the debug output to the given writer. If w is
+// nil, this is equivalent to SetDebug(false).
+func (m *Mail) SetDebugOutput(w io.Writer) *Mail {
+	m.debugOut = w
 	return m
 }

--- a/options.go
+++ b/options.go
@@ -32,18 +32,15 @@ func (m *Mail) SetDebugOutput(w io.Writer) *Mail {
 	return m
 }
 
-// AppendTo adds a recipient to the Mail. The name argument is the
-// "proper name" of the recipient and may be empty. The address must be
-// in the form "user@domain".
-func (m *Mail) AppendTo(name, address string) *Mail {
-	m.To = append(m.To, &mail.Address{Name: name, Address: address})
+// AppendTo adds a recipient to the Mail.
+func (m *Mail) AppendTo(toAddress *mail.Address) *Mail {
+	m.To = append(m.To, toAddress)
 	return m
 }
 
-// SetFrom updates the sender's address. Like AppendTo(), name may be
-// empty, and address must be in the form "user@domain".
-func (m *Mail) SetFrom(name, address string) *Mail {
-	m.From = &mail.Address{Name: name, Address: address}
+// SetFrom updates (replaces) the sender's address.
+func (m *Mail) SetFrom(fromAddress *mail.Address) *Mail {
+	m.From = fromAddress
 	return m
 }
 
@@ -79,17 +76,14 @@ func DebugOutput(w io.Writer) Option {
 	return optionFunc(func(m *Mail) { m.SetDebugOutput(w) })
 }
 
-// To adds a recipient to the Mail. The name argument is the "proper name"
-// of the recipient and may be empty. The address must be in the form
-// "user@domain".
-func To(name, address string) Option {
-	return optionFunc(func(m *Mail) { m.AppendTo(name, address) })
+// To adds a recipient to the Mail.
+func To(address *mail.Address) Option {
+	return optionFunc(func(m *Mail) { m.AppendTo(address) })
 }
 
-// From updates the sender's address. Like To(), name may be empty, and
-// address must be in the form "user@domain".
-func From(name, address string) Option {
-	return optionFunc(func(m *Mail) { m.SetFrom(name, address) })
+// From sets the sender's address.
+func From(fromAddress *mail.Address) Option {
+	return optionFunc(func(m *Mail) { m.SetFrom(fromAddress) })
 }
 
 // Subject sets the mail subject.

--- a/options.go
+++ b/options.go
@@ -6,9 +6,11 @@ import (
 	"os"
 )
 
-// SetSendmail modifies the path to the sendmail binary.
-func (m *Mail) SetSendmail(path string) *Mail {
-	m.sendmail = path
+// SetSendmail modifies the path to the sendmail binary. You can pass
+// additional arguments, if you need to.
+func (m *Mail) SetSendmail(path string, args ...string) *Mail {
+	m.sendmailPath = path
+	m.sendmailArgs = args
 	return m
 }
 
@@ -61,8 +63,8 @@ type optionFunc func(*Mail)
 func (o optionFunc) execute(m *Mail) { o(m) }
 
 // Sendmail modifies the path to the sendmail binary.
-func Sendmail(path string) Option {
-	return optionFunc(func(m *Mail) { m.SetSendmail(path) })
+func Sendmail(path string, args ...string) Option {
+	return optionFunc(func(m *Mail) { m.SetSendmail(path, args...) })
 }
 
 // Debug sets the debug output to stderr if active is true, else it

--- a/options.go
+++ b/options.go
@@ -1,0 +1,7 @@
+package sendmail
+
+// SetSendmail modifies the path to the sendmail binary.
+func (m *Mail) SetSendmail(path string) *Mail {
+	m.sendmail = path
+	return m
+}

--- a/options.go
+++ b/options.go
@@ -50,3 +50,47 @@ func (m *Mail) SetSubject(subject string) *Mail {
 	m.Subject = subject
 	return m
 }
+
+// Option is used in the Mail constructor.
+type Option interface {
+	execute(*Mail)
+}
+
+type optionFunc func(*Mail)
+
+func (o optionFunc) execute(m *Mail) { o(m) }
+
+// Sendmail modifies the path to the sendmail binary.
+func Sendmail(path string) Option {
+	return optionFunc(func(m *Mail) { m.SetSendmail(path) })
+}
+
+// Debug sets the debug output to stderr if active is true, else it
+// removes the debug output. Use SetDebugOutput to set it to something else.
+func Debug(active bool) Option {
+	return optionFunc(func(m *Mail) { m.SetDebug(active) })
+}
+
+// DebugOutput sets the debug output to the given writer. If w is nil,
+// this is equivalent to SetDebug(false).
+func DebugOutput(w io.Writer) Option {
+	return optionFunc(func(m *Mail) { m.SetDebugOutput(w) })
+}
+
+// To adds a recipient to the Mail. The name argument is the "proper name"
+// of the recipient and may be empty. The address must be in the form
+// "user@domain".
+func To(name, address string) Option {
+	return optionFunc(func(m *Mail) { m.AppendTo(name, address) })
+}
+
+// From updates the sender's address. Like To(), name may be empty, and
+// address must be in the form "user@domain".
+func From(name, address string) Option {
+	return optionFunc(func(m *Mail) { m.SetFrom(name, address) })
+}
+
+// Subject sets the mail subject.
+func Subject(subject string) Option {
+	return optionFunc(func(m *Mail) { m.SetSubject(subject) })
+}

--- a/options.go
+++ b/options.go
@@ -38,6 +38,18 @@ func (m *Mail) AppendTo(toAddress *mail.Address) *Mail {
 	return m
 }
 
+// AppendCC adds a carbon-copy recipient to the Mail.
+func (m *Mail) AppendCC(ccAddress *mail.Address) *Mail {
+	m.CC = append(m.CC, ccAddress)
+	return m
+}
+
+// AppendBCC adds a blind carbon-copy recipient to the Mail.
+func (m *Mail) AppendBCC(bccAddress *mail.Address) *Mail {
+	m.BCC = append(m.BCC, bccAddress)
+	return m
+}
+
 // SetFrom updates (replaces) the sender's address.
 func (m *Mail) SetFrom(fromAddress *mail.Address) *Mail {
 	m.From = fromAddress

--- a/options_test.go
+++ b/options_test.go
@@ -31,8 +31,8 @@ func TestChaningOptions(t *testing.T) {
 	}
 
 	m.SetSubject("Test subject").
-		SetFrom("Dominik", "dominik@example.org").
-		AppendTo("Dominik2", "dominik2@example.org").
+		SetFrom(&mail.Address{Name: "Dominik", Address: "dominik@example.org"}).
+		AppendTo(&mail.Address{Name: "Dominik2", Address: "dominik2@example.org"}).
 		SetDebugOutput(&buf).
 		SetSendmail("/bin/true")
 
@@ -87,22 +87,22 @@ func TestOptions(t *testing.T) {
 	}
 
 	// To() appends list
-	o = To("Ktoś", "info@example.com")
+	o = To(&mail.Address{Name: "Ktoś", Address: "info@example.com"})
 	if o.execute(m); len(m.To) != 1 {
 		t.Errorf("Expected len(To) to be 1, got %d: %+v", len(m.To), m.To)
 	}
-	o = To("Ktoś2", "info2@example.com")
+	o = To(&mail.Address{Name: "Ktoś2", Address: "info2@example.com"})
 	if o.execute(m); len(m.To) != 2 {
 		t.Errorf("Expected len(To) to be 2, got %d: %+v", len(m.To), m.To)
 	}
 
 	// From() updates current sender
-	o = From("Michał", "me@example.com")
+	o = From(&mail.Address{Name: "Michał", Address: "me@example.com"})
 	if o.execute(m); m.From == nil || m.From.Address != "me@example.com" {
 		expected := mail.Address{Name: "Michał", Address: "me@example.com"}
 		t.Errorf("Expected From address to be %s, got %s", expected, m.From)
 	}
-	o = From("Michał", "me@example.com")
+	o = From(&mail.Address{Name: "Michał", Address: "me@example.com"})
 	if o.execute(m); m.From == nil || m.From.Address != "me@example.com" {
 		expected := mail.Address{Name: "Michał", Address: "me@example.com"}
 		t.Errorf("Expected From address to be %s, got %s", expected, m.From)

--- a/options_test.go
+++ b/options_test.go
@@ -1,14 +1,27 @@
 package sendmail
 
 import (
+	"bytes"
 	"testing"
 )
 
 func TestChaningOptions(t *testing.T) {
+	var buf bytes.Buffer
 	m := &Mail{}
-	m.SetSendmail("/bin/true")
+
+	if m.sendmail != "" {
+		t.Errorf("Expected initial sendmail to be empty, got %q", m.sendmail)
+	}
+	if m.debugOut != nil {
+		t.Errorf("Expected initial debugOut to be nil, got %T", m.debugOut)
+	}
+
+	m.SetSendmail("/bin/true").SetDebugOutput(&buf)
 
 	if m.sendmail != "/bin/true" {
 		t.Errorf("Expected sendmail to be %q, got %q", "/bin/true", m.sendmail)
+	}
+	if m.debugOut != &buf {
+		t.Errorf("Expected debugOut to be %T (buf), got %T", &buf, m.debugOut)
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -56,9 +56,8 @@ func TestChaningOptions(t *testing.T) {
 
 func TestOptions(t *testing.T) {
 	m := &Mail{}
-	var o Option
 
-	o = Sendmail("/foo/bar")
+	o := Sendmail("/foo/bar")
 	if o.execute(m); m.sendmail != "/foo/bar" {
 		t.Errorf("Expected sendmail to be %q, got %q", "/foo/bar", m.sendmail)
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,14 @@
+package sendmail
+
+import (
+	"testing"
+)
+
+func TestChaningOptions(t *testing.T) {
+	m := &Mail{}
+	m.SetSendmail("/bin/true")
+
+	if m.sendmail != "/bin/true" {
+		t.Errorf("Expected sendmail to be %q, got %q", "/bin/true", m.sendmail)
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -2,13 +2,26 @@ package sendmail
 
 import (
 	"bytes"
+	"net/mail"
 	"testing"
 )
 
 func TestChaningOptions(t *testing.T) {
 	var buf bytes.Buffer
-	m := &Mail{}
-
+	m := &Mail{
+		To: []*mail.Address{
+			&mail.Address{Name: "Michał", Address: "me@example.com"},
+		},
+	}
+	if m.Subject != "" {
+		t.Errorf("Expected subject to be empty, got %q", m.Subject)
+	}
+	if len(m.To) != 1 {
+		t.Errorf("Expected len(To) to be 1, got %d: %+v", len(m.To), m.To)
+	}
+	if m.From != nil {
+		t.Errorf("Expected From address to be nil, got %s", m.From)
+	}
 	if m.sendmail != "" {
 		t.Errorf("Expected initial sendmail to be empty, got %q", m.sendmail)
 	}
@@ -16,8 +29,22 @@ func TestChaningOptions(t *testing.T) {
 		t.Errorf("Expected initial debugOut to be nil, got %T", m.debugOut)
 	}
 
-	m.SetSendmail("/bin/true").SetDebugOutput(&buf)
+	m.SetSubject("Test subject").
+		SetFrom("Dominik", "dominik@example.org").
+		AppendTo("Dominik2", "dominik2@example.org").
+		SetDebugOutput(&buf).
+		SetSendmail("/bin/true")
 
+	if m.Subject != "Test subject" {
+		t.Errorf("Expected subject to be %q, got %q", "Test subject", m.Subject)
+	}
+	if len(m.To) != 2 {
+		t.Errorf("Expected len(To) to be 2, got %d: %+v", len(m.To), m.To)
+	}
+	if m.From == nil || m.From.Address != "dominik@example.org" {
+		expected := mail.Address{Name: "Dominik", Address: "dominik@example.org"}
+		t.Errorf("Expected From address to be %s, got %s", expected, m.From)
+	}
 	if m.sendmail != "/bin/true" {
 		t.Errorf("Expected sendmail to be %q, got %q", "/bin/true", m.sendmail)
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -23,8 +23,8 @@ func TestChaningOptions(t *testing.T) {
 	if m.From != nil {
 		t.Errorf("Expected From address to be nil, got %s", m.From)
 	}
-	if m.sendmail != "" {
-		t.Errorf("Expected initial sendmail to be empty, got %q", m.sendmail)
+	if m.sendmailPath != "" {
+		t.Errorf("Expected initial sendmail to be empty, got %q", m.sendmailPath)
 	}
 	if m.debugOut != nil {
 		t.Errorf("Expected initial debugOut to be nil, got %T", m.debugOut)
@@ -46,8 +46,8 @@ func TestChaningOptions(t *testing.T) {
 		expected := mail.Address{Name: "Dominik", Address: "dominik@example.org"}
 		t.Errorf("Expected From address to be %s, got %s", expected, m.From)
 	}
-	if m.sendmail != "/bin/true" {
-		t.Errorf("Expected sendmail to be %q, got %q", "/bin/true", m.sendmail)
+	if m.sendmailPath != "/bin/true" {
+		t.Errorf("Expected sendmail to be %q, got %q", "/bin/true", m.sendmailPath)
 	}
 	if m.debugOut != &buf {
 		t.Errorf("Expected debugOut to be %T (buf), got %T", &buf, m.debugOut)
@@ -57,9 +57,12 @@ func TestChaningOptions(t *testing.T) {
 func TestOptions(t *testing.T) {
 	m := &Mail{}
 
-	o := Sendmail("/foo/bar")
-	if o.execute(m); m.sendmail != "/foo/bar" {
-		t.Errorf("Expected sendmail to be %q, got %q", "/foo/bar", m.sendmail)
+	o := Sendmail("/foo/bar", "--verbose")
+	if o.execute(m); m.sendmailPath != "/foo/bar" {
+		t.Errorf("Expected sendmail to be %q, got %q", "/foo/bar", m.sendmailPath)
+	}
+	if len(m.sendmailArgs) != 1 || m.sendmailArgs[0] != "--verbose" {
+		t.Errorf("Expected sendmail args to be %q, got %v", "--verbose", m.sendmailArgs)
 	}
 
 	o = Debug(true)

--- a/sendmail.go
+++ b/sendmail.go
@@ -23,6 +23,8 @@ type Mail struct {
 	Subject string
 	From    *mail.Address
 	To      []*mail.Address
+	CC      []*mail.Address
+	BCC     []*mail.Address
 	Header  http.Header
 	Text    bytes.Buffer
 	HTML    bytes.Buffer
@@ -66,12 +68,28 @@ func (m *Mail) Send() error {
 		arg[i] = t.Address
 	}
 	m.Header.Set("To", strings.Join(to, ", "))
+
+	if cc := concatAddresses(m.CC); cc != "" {
+		m.Header.Set("CC", cc)
+	}
+	if bcc := concatAddresses(m.BCC); bcc != "" {
+		m.Header.Set("BCC", bcc)
+	}
+
 	if m.debugOut != nil {
 		_, err := m.WriteTo(m.debugOut)
 		return err
 	}
 
 	return m.exec(arg...)
+}
+
+func concatAddresses(list []*mail.Address) string {
+	buf := make([]string, 0, len(list))
+	for _, addr := range list {
+		buf = append(buf, addr.String())
+	}
+	return strings.Join(buf, ", ")
 }
 
 // exec handles sendmail command invokation.

--- a/sendmail.go
+++ b/sendmail.go
@@ -20,7 +20,6 @@ var _, debug = os.LookupEnv("DEBUG")
 
 // SendmailDefault points to the default sendmail binary location.
 const SendmailDefault = "/usr/sbin/sendmail"
-const debugDelimiter = "\n----------------------------------------------------------------------"
 
 // Mail defines basic mail structure and headers
 type Mail struct {
@@ -68,9 +67,7 @@ func (m *Mail) Send() error {
 	}
 	m.Header.Set("To", strings.Join(to, ", "))
 	if m.debugOut != nil {
-		fmt.Println(debugDelimiter)
 		m.WriteTo(m.debugOut)
-		fmt.Println(debugDelimiter)
 		return nil
 	}
 

--- a/sendmail.go
+++ b/sendmail.go
@@ -27,13 +27,14 @@ type Mail struct {
 	Text    bytes.Buffer
 	HTML    bytes.Buffer
 
-	sendmail string
-	debugOut io.Writer
+	sendmailPath string
+	sendmailArgs []string
+	debugOut     io.Writer
 }
 
 // New creates a new Mail instance with the given options.
 func New(options ...Option) (m *Mail) {
-	m = &Mail{sendmail: SendmailDefault}
+	m = &Mail{sendmailPath: SendmailDefault}
 	for _, option := range options {
 		option.execute(m)
 	}
@@ -72,10 +73,11 @@ func (m *Mail) Send() error {
 // exec handles sendmail command invokation.
 func (m *Mail) exec(arg ...string) error {
 	bin := SendmailDefault
-	if m.sendmail != "" {
-		bin = m.sendmail
+	if m.sendmailPath != "" {
+		bin = m.sendmailPath
 	}
-	cmd := exec.Command(bin, arg...)
+	args := append(append([]string{}, m.sendmailArgs...), arg...)
+	cmd := exec.Command(bin, args...)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -105,7 +107,7 @@ func (m *Mail) exec(arg ...string) error {
 }
 
 // WriteTo writes headers and content of the email to io.Writer
-func (m *Mail) WriteTo(wr io.Writer) error { //nolint: vet
+func (m *Mail) WriteTo(wr io.Writer) error { // nolint: vet
 	isText := m.Text.Len() > 0
 	isHTML := m.HTML.Len() > 0
 

--- a/sendmail.go
+++ b/sendmail.go
@@ -11,12 +11,9 @@ import (
 	"mime"
 	"net/http"
 	"net/mail"
-	"os"
 	"os/exec"
 	"strings"
 )
-
-var _, debug = os.LookupEnv("DEBUG")
 
 // SendmailDefault points to the default sendmail binary location.
 const SendmailDefault = "/usr/sbin/sendmail"
@@ -66,8 +63,7 @@ func (m *Mail) Send() error {
 	}
 	m.Header.Set("To", strings.Join(to, ", "))
 	if m.debugOut != nil {
-		m.WriteTo(m.debugOut)
-		return nil
+		return m.WriteTo(m.debugOut)
 	}
 
 	return m.exec(arg...)
@@ -109,7 +105,7 @@ func (m *Mail) exec(arg ...string) error {
 }
 
 // WriteTo writes headers and content of the email to io.Writer
-func (m *Mail) WriteTo(wr io.Writer) error {
+func (m *Mail) WriteTo(wr io.Writer) error { //nolint: vet
 	isText := m.Text.Len() > 0
 	isHTML := m.HTML.Len() > 0
 

--- a/sendmail.go
+++ b/sendmail.go
@@ -20,6 +20,7 @@ var _, debug = os.LookupEnv("DEBUG")
 
 // SendmailDefault points to the default sendmail binary location.
 const SendmailDefault = "/usr/sbin/sendmail"
+const debugDelimiter = "\n----------------------------------------------------------------------"
 
 // Mail defines basic mail structure and headers
 type Mail struct {
@@ -31,6 +32,7 @@ type Mail struct {
 	HTML    bytes.Buffer
 
 	sendmail string
+	debugOut io.Writer
 }
 
 // Send sends an email, or prints it on stderr,
@@ -56,11 +58,10 @@ func (m *Mail) Send() error {
 		arg[i] = t.Address
 	}
 	m.Header.Set("To", strings.Join(to, ", "))
-	if debug {
-		delimiter := "\n" + strings.Repeat("-", 70)
-		fmt.Println(delimiter)
-		m.WriteTo(os.Stdout)
-		fmt.Println(delimiter)
+	if m.debugOut != nil {
+		fmt.Println(debugDelimiter)
+		m.WriteTo(m.debugOut)
+		fmt.Println(debugDelimiter)
 		return nil
 	}
 

--- a/sendmail.go
+++ b/sendmail.go
@@ -34,7 +34,10 @@ type Mail struct {
 
 // New creates a new Mail instance with the given options.
 func New(options ...Option) (m *Mail) {
-	m = &Mail{sendmailPath: SendmailDefault}
+	m = &Mail{
+		Header:       make(http.Header),
+		sendmailPath: SendmailDefault,
+	}
 	for _, option := range options {
 		option.execute(m)
 	}

--- a/sendmail.go
+++ b/sendmail.go
@@ -35,6 +35,15 @@ type Mail struct {
 	debugOut io.Writer
 }
 
+// New creates a new Mail instance with the given options.
+func New(options ...Option) (m *Mail) {
+	m = &Mail{sendmail: SendmailDefault}
+	for _, option := range options {
+		option.execute(m)
+	}
+	return
+}
+
 // Send sends an email, or prints it on stderr,
 // when environment variable `DEBUG` is set.
 func (m *Mail) Send() error {

--- a/sendmail_test.go
+++ b/sendmail_test.go
@@ -1,6 +1,7 @@
 package sendmail
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/mail"
@@ -64,5 +65,33 @@ func TestToError(t *testing.T) {
 	}
 	if sm.Send() == nil {
 		t.Errorf("Expected an error because of missing `To` addresses")
+	}
+}
+
+func TestNew(t *testing.T) {
+	var buf bytes.Buffer
+	m := New(
+		Subject("Test subject"),
+		From("Dominik", "dominik@example.org"),
+		To("Dominik2", "dominik2@example.org"),
+		DebugOutput(&buf),
+		Sendmail("/bin/true"),
+	)
+
+	if m.Subject != "Test subject" {
+		t.Errorf("Expected subject to be %q, got %q", "Test subject", m.Subject)
+	}
+	if len(m.To) != 1 {
+		t.Errorf("Expected len(To) to be 1, got %d: %+v", len(m.To), m.To)
+	}
+	if m.From == nil || m.From.Address != "dominik@example.org" {
+		expected := mail.Address{Name: "Dominik", Address: "dominik@example.org"}
+		t.Errorf("Expected From address to be %s, got %s", expected, m.From)
+	}
+	if m.sendmail != "/bin/true" {
+		t.Errorf("Expected sendmail to be %q, got %q", "/bin/true", m.sendmail)
+	}
+	if m.debugOut != &buf {
+		t.Errorf("Expected debugOut to be %T (buf), got %T", &buf, m.debugOut)
 	}
 }

--- a/sendmail_test.go
+++ b/sendmail_test.go
@@ -111,6 +111,26 @@ func TestHTMLMail(t *testing.T) {
 	}
 }
 
+func TestWriteTo(t *testing.T) {
+	var buf bytes.Buffer
+	sm := New(
+		Subject("Cześć"),
+		From(maddr("Michał", "me@")),
+		To(maddr("Ktoś", "info@")),
+		To(maddr("Ktoś2", "info2@")),
+		DebugOutput(&buf),
+	)
+	io.WriteString(&sm.Text, ":)\r\n")
+
+	actual, err := sm.WriteTo(&buf)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if expected := int64(buf.Len()); actual != expected {
+		t.Errorf("expeted to have written %d bytes, got %d", expected, actual)
+	}
+}
+
 func TestFromError(t *testing.T) {
 	sm := Mail{
 		To: []*mail.Address{maddr("Ktoś", "info@")},

--- a/sendmail_test.go
+++ b/sendmail_test.go
@@ -149,8 +149,8 @@ func TestNew(t *testing.T) {
 		expected := mail.Address{Name: "Dominik", Address: "dominik@example.org"}
 		t.Errorf("Expected From address to be %s, got %s", expected, m.From)
 	}
-	if m.sendmail != "/bin/true" {
-		t.Errorf("Expected sendmail to be %q, got %q", "/bin/true", m.sendmail)
+	if m.sendmailPath != "/bin/true" {
+		t.Errorf("Expected sendmail to be %q, got %q", "/bin/true", m.sendmailPath)
 	}
 	if m.debugOut != &buf {
 		t.Errorf("Expected debugOut to be %T (buf), got %T", &buf, m.debugOut)

--- a/sendmail_test.go
+++ b/sendmail_test.go
@@ -13,10 +13,6 @@ func maddr(name, address string) *mail.Address {
 	return &mail.Address{Name: name, Address: address + domain}
 }
 
-func init() {
-	Binary = "/bin/true"
-}
-
 func TestSend(tc *testing.T) {
 	tc.Run("debug:true", func(t *testing.T) {
 		testSend(t, true)
@@ -39,6 +35,8 @@ func testSend(t *testing.T, withDebug bool) {
 			maddr("Ktoś2", "info2@"),
 		},
 	}
+	sm.SetSendmail("/bin/true")
+
 	io.WriteString(&sm.Text, ":)\r\n")
 	if err := sm.Send(); err != nil {
 		t.Errorf("(debug=%v) %v", withDebug, err)

--- a/sendmail_test.go
+++ b/sendmail_test.go
@@ -56,9 +56,9 @@ func TestTextMail(t *testing.T) {
 	var buf bytes.Buffer
 	sm := New(
 		Subject("Cześć"),
-		From("Michał", "me@"+domain),
-		To("Ktoś", "info@"+domain),
-		To("Ktoś2", "info2@"+domain),
+		From(maddr("Michał", "me@")),
+		To(maddr("Ktoś", "info@")),
+		To(maddr("Ktoś2", "info2@")),
 		DebugOutput(&buf),
 	)
 	io.WriteString(&sm.Text, ":)\r\n")
@@ -85,9 +85,9 @@ func TestHTMLMail(t *testing.T) {
 	var buf bytes.Buffer
 	sm := New(
 		Subject("Cześć"),
-		From("Michał", "me@"+domain),
-		To("Ktoś", "info@"+domain),
-		To("Ktoś2", "info2@"+domain),
+		From(maddr("Michał", "me@")),
+		To(maddr("Ktoś", "info@")),
+		To(maddr("Ktoś2", "info2@")),
 		DebugOutput(&buf),
 	)
 	io.WriteString(&sm.HTML, "<p>:)</p>\r\n")
@@ -133,8 +133,8 @@ func TestNew(t *testing.T) {
 	var buf bytes.Buffer
 	m := New(
 		Subject("Test subject"),
-		From("Dominik", "dominik@example.org"),
-		To("Dominik2", "dominik2@example.org"),
+		From(maddr("Dominik", "dominik@")),
+		To(maddr("Dominik2", "dominik2@")),
 		DebugOutput(&buf),
 		Sendmail("/bin/true"),
 	)
@@ -145,8 +145,8 @@ func TestNew(t *testing.T) {
 	if len(m.To) != 1 {
 		t.Errorf("Expected len(To) to be 1, got %d: %+v", len(m.To), m.To)
 	}
-	if m.From == nil || m.From.Address != "dominik@example.org" {
-		expected := mail.Address{Name: "Dominik", Address: "dominik@example.org"}
+	if m.From == nil || m.From.Address != "dominik@example.com" {
+		expected := mail.Address{Name: "Dominik", Address: "dominik@example.com"}
 		t.Errorf("Expected From address to be %s, got %s", expected, m.From)
 	}
 	if m.sendmailPath != "/bin/true" {

--- a/sendmail_test.go
+++ b/sendmail_test.go
@@ -15,18 +15,16 @@ func maddr(name, address string) *mail.Address {
 
 func TestSend(tc *testing.T) {
 	tc.Run("debug:true", func(t *testing.T) {
+		t.Parallel()
 		testSend(t, true)
 	})
 	tc.Run("debug:false", func(t *testing.T) {
+		t.Parallel()
 		testSend(t, false)
 	})
 }
 
 func testSend(t *testing.T, withDebug bool) {
-	oldDebug := debug
-	debug = withDebug
-	defer func() { debug = oldDebug }()
-
 	sm := Mail{
 		Subject: "Cześć",
 		From:    maddr("Michał", "me@"),
@@ -35,7 +33,7 @@ func testSend(t *testing.T, withDebug bool) {
 			maddr("Ktoś2", "info2@"),
 		},
 	}
-	sm.SetSendmail("/bin/true")
+	sm.SetSendmail("/bin/true").SetDebug(withDebug)
 
 	io.WriteString(&sm.Text, ":)\r\n")
 	if err := sm.Send(); err != nil {

--- a/sendmail_test.go
+++ b/sendmail_test.go
@@ -82,6 +82,36 @@ func TestTextMail(t *testing.T) {
 	}
 }
 
+func TestHTMLMail(t *testing.T) {
+	var buf bytes.Buffer
+	sm := New(
+		Subject("Cześć"),
+		From("Michał", "me@"+domain),
+		To("Ktoś", "info@"+domain),
+		To("Ktoś2", "info2@"+domain),
+		DebugOutput(&buf),
+	)
+	io.WriteString(&sm.HTML, "<p>:)</p>\r\n")
+
+	expected := strings.Join([]string{
+		"Content-Type: text/html; charset=UTF-8",
+		"From: =?utf-8?q?Micha=C5=82?= <me@example.com>",
+		"Subject: =?utf-8?q?Cze=C5=9B=C4=87?=",
+		"To: =?utf-8?q?Kto=C5=9B?= <info@example.com>, =?utf-8?q?Kto=C5=9B2?= <info2@example.com>",
+		"",
+		"<p>:)</p>",
+		"",
+	}, "\r\n")
+
+	if err := sm.Send(); err != nil {
+		t.Errorf("Error writing to buffer: %v", err)
+	}
+	if actual := buf.String(); actual != expected {
+		fmt.Fprintln(os.Stderr, actual)
+		t.Errorf("Unexpected mail content")
+	}
+}
+
 func TestFromError(t *testing.T) {
 	sm := Mail{
 		To: []*mail.Address{maddr("Ktoś", "info@")},

--- a/sendmail_test.go
+++ b/sendmail_test.go
@@ -77,8 +77,7 @@ func TestTextMail(t *testing.T) {
 		t.Errorf("Error writing to buffer: %v", err)
 	}
 	if actual := buf.String(); actual != expected {
-		fmt.Fprintln(os.Stderr, actual)
-		t.Errorf("Unexpected mail content")
+		t.Error("Unexpected mail content", actual)
 	}
 }
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -22,9 +22,9 @@ func TestValidate(tc *testing.T) {
 			e := email
 			t.Parallel()
 			err := Validate(e.Address)
-			if err == nil && e.IsValid == false {
+			if err == nil && !e.IsValid {
 				t.Errorf("Email `%s` is valid, but should be invalid", e.Address)
-			} else if err != nil && e.IsValid == true {
+			} else if err != nil && e.IsValid {
 				t.Errorf("Email `%s` is invalid, but should be valid", e.Address)
 			}
 		})


### PR DESCRIPTION
Hey,

whilst using this more, I found I needed a more conveniant interface.

The first part in this commit series will introduce a `sendmail.Option` type and a `sendmail.New()` constructor function, which takes said Options as arguments. Together, they allow code to look like this:

```go
// taken from `sendmail_test.go`, `TestTextMail`
var buf bytes.Buffer
sm := New(
	Subject("Cześć"),
	From("Michał", "me@example.com"),
	To("Ktoś", "info@example.com"),
	To("Ktoś2", "info2@example.com"),
	DebugOutput(&buf),
)
```

or like this:

```go
// taken from `options_test.go`, `TestChainingOptions`
m.SetSubject("Test subject").
	SetFrom("Dominik", "dominik@example.org").
	AppendTo("Dominik2", "dominik2@example.org").
	SetDebugOutput(&buf).
	SetSendmail("/bin/true")
```

Another subset of the commits moves the recently introduced global `Binary` variable, as well as the debug variable into the `Mail` type. As it turns out, global variables are a source of frustration in concurrent applications :-) You can see an example in the snippets above (`SetOutput`/`SetSendmail`).

I also started with HTML mails, but mixed-content (multipart, Text+HTML) isn't there yet. I'd like to harvest some code from [mailyak](https://github.com/domodwyer/mailyak), but the current license prevents me from that. Having a solid MIME multipart implementation would also allow attachments to the mail.